### PR TITLE
replace DropCloud with ownDrop, fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ownDrop
 
-Your private One-Click uploader for OwnCloud, build on and for Mac OS X.
+Your private one-click uploader for [ownCloud](https://owncloud.org/), built on and for Mac OS X.
 
 ![promo](https://raw.githubusercontent.com/Leandros/ownDrop/master/Promo/promo.gif)
 
@@ -8,7 +8,7 @@ Your private One-Click uploader for OwnCloud, build on and for Mac OS X.
 ### Installation
 Download the current version [here](https://github.com/Leandros/ownDrop/releases/download/0.1.0/DropCloud-0.1.0.zip). Unzip the file, move `DropCloud.app` to the `Application` folder and start it.
 
-Before first use, you have to fill in your **OwnCloud** server and your login, to do so, click on the icon in the menu bar and go to the settings. Below you can see an example:
+Before first use you have to fill in your **ownCloud** server and your credentials. Just click on the icon in the menu bar and go to the settings. Below you can see an example:
 
 ![example](https://raw.githubusercontent.com/Leandros/ownDrop/master/Promo/example.png)
 
@@ -19,14 +19,14 @@ Before first use, you have to fill in your **OwnCloud** server and your login, t
 
 
 ### Development
-DropCloud uses [CocoaPods](http://cocoapods.org) to handle it's dependencies and the [git-flow](http://nvie.com/posts/a-successful-git-branching-model/) branching model. The master branch is always stable and the develop branch is the version, which is currently in development.
-To build DropCloud, you have to install all dependencies first (`pod install`).
+ownDrop uses [CocoaPods](http://cocoapods.org) to handle its dependencies and the [git-flow](http://nvie.com/posts/a-successful-git-branching-model/) branching model. The master branch is always stable and the develop branch is the version, which is currently in development.
+To build ownDrop you have to install all dependencies first (`pod install`).
 Make sure to open the `DropCloud.xcworkspace`, instead of the `.xcodeproj`.
 
 
 ### Contact
-DropCloud is developed and maintained by [Arvid Gerstmann](http://github.com/leandros). Contact through Github is encouraged, otherwise you can send an E-Mail to dev@arvid-g.de.
+ownDrop is developed and maintained by [Arvid Gerstmann](http://github.com/leandros). Contact through Github is encouraged, otherwise you can send an E-Mail to dev@arvid-g.de.
 
 
 ### License
-DropCloud is licensed under GPLv3. See the [LICENSE](https://github.com/Leandros/ownDrop/blob/master/LICENSE) file for more information.
+ownDrop is licensed under GPLv3. See the [LICENSE](https://github.com/Leandros/ownDrop/blob/master/LICENSE) file for more information.


### PR DESCRIPTION
- replace DropCloud with ownDrop (I didn’t replace the download link, nor the DropCloud.app nor the paths which still include DropCloud)
- ownCloud is written with lowecase o
- fixed some capitalization and comma typos
