### PR TITLE
Feature/bugfix remove recent drops title when first upload succeeds

### DIFF
--- a/DropCloud.xcodeproj/project.pbxproj
+++ b/DropCloud.xcodeproj/project.pbxproj
@@ -64,7 +64,7 @@
 		0C217A451927D6E100329724 /* AGAppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AGAppDelegate.h; sourceTree = "<group>"; };
 		0C217A461927D6E100329724 /* AGAppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AGAppDelegate.m; sourceTree = "<group>"; };
 		0C217A4B1927D6E100329724 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
-		0C217A511927D6E100329724 /* DropCloudTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; name = DropCloudTests.xctest; path = ownDropTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		0C217A511927D6E100329724 /* ownDropTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ownDropTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		0C217A521927D6E100329724 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		0C217A591927D6E100329724 /* DropCloudTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "DropCloudTests-Info.plist"; sourceTree = "<group>"; };
 		0C217A5B1927D6E100329724 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -150,7 +150,7 @@
 			isa = PBXGroup;
 			children = (
 				0C217A301927D6E100329724 /* ownDrop.app */,
-				0C217A511927D6E100329724 /* DropCloudTests.xctest */,
+				0C217A511927D6E100329724 /* ownDropTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -326,7 +326,7 @@
 			);
 			name = ownDropTests;
 			productName = DropCloudTests;
-			productReference = 0C217A511927D6E100329724 /* DropCloudTests.xctest */;
+			productReference = 0C217A511927D6E100329724 /* ownDropTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 /* End PBXNativeTarget section */

--- a/DropCloud.xcworkspace/xcshareddata/DropCloud.xccheckout
+++ b/DropCloud.xcworkspace/xcshareddata/DropCloud.xccheckout
@@ -5,34 +5,34 @@
 	<key>IDESourceControlProjectFavoriteDictionaryKey</key>
 	<false/>
 	<key>IDESourceControlProjectIdentifier</key>
-	<string>F6E3E33B-9FF9-4AC4-BCB6-FBA3FE9D21DC</string>
+	<string>0F840F11-9BB1-4CAA-9BA8-31BA36C5C441</string>
 	<key>IDESourceControlProjectName</key>
 	<string>DropCloud</string>
 	<key>IDESourceControlProjectOriginsDictionary</key>
 	<dict>
-		<key>B5B95C91-889D-4DA8-8B25-2D38FEEB9B0B</key>
-		<string>ssh://github.com/Leandros/ownDrop.git</string>
+		<key>2137045C-9B38-45E5-9C4F-342C5A2E462F</key>
+		<string>ssh://github.com/kanedo/ownDrop.git</string>
 	</dict>
 	<key>IDESourceControlProjectPath</key>
 	<string>DropCloud.xcworkspace</string>
 	<key>IDESourceControlProjectRelativeInstallPathDictionary</key>
 	<dict>
-		<key>B5B95C91-889D-4DA8-8B25-2D38FEEB9B0B</key>
+		<key>2137045C-9B38-45E5-9C4F-342C5A2E462F</key>
 		<string>..</string>
 	</dict>
 	<key>IDESourceControlProjectURL</key>
-	<string>ssh://github.com/Leandros/ownDrop.git</string>
+	<string>ssh://github.com/kanedo/ownDrop.git</string>
 	<key>IDESourceControlProjectVersion</key>
 	<integer>110</integer>
 	<key>IDESourceControlProjectWCCIdentifier</key>
-	<string>B5B95C91-889D-4DA8-8B25-2D38FEEB9B0B</string>
+	<string>2137045C-9B38-45E5-9C4F-342C5A2E462F</string>
 	<key>IDESourceControlProjectWCConfigurations</key>
 	<array>
 		<dict>
 			<key>IDESourceControlRepositoryExtensionIdentifierKey</key>
 			<string>public.vcs.git</string>
 			<key>IDESourceControlWCCIdentifierKey</key>
-			<string>B5B95C91-889D-4DA8-8B25-2D38FEEB9B0B</string>
+			<string>2137045C-9B38-45E5-9C4F-342C5A2E462F</string>
 			<key>IDESourceControlWCCName</key>
 			<string>ownDrop</string>
 		</dict>

--- a/DropCloud.xcworkspace/xcshareddata/DropCloud.xccheckout
+++ b/DropCloud.xcworkspace/xcshareddata/DropCloud.xccheckout
@@ -5,36 +5,36 @@
 	<key>IDESourceControlProjectFavoriteDictionaryKey</key>
 	<false/>
 	<key>IDESourceControlProjectIdentifier</key>
-	<string>2F1F12A6-5BBA-47C8-B09C-ABC183D00777</string>
+	<string>F6E3E33B-9FF9-4AC4-BCB6-FBA3FE9D21DC</string>
 	<key>IDESourceControlProjectName</key>
 	<string>DropCloud</string>
 	<key>IDESourceControlProjectOriginsDictionary</key>
 	<dict>
-		<key>5F73378B-9B1E-4D93-A7B2-48552D49D55F</key>
-		<string>ssh://github.com/Leandros/DropCloud.git</string>
+		<key>B5B95C91-889D-4DA8-8B25-2D38FEEB9B0B</key>
+		<string>ssh://github.com/Leandros/ownDrop.git</string>
 	</dict>
 	<key>IDESourceControlProjectPath</key>
 	<string>DropCloud.xcworkspace</string>
 	<key>IDESourceControlProjectRelativeInstallPathDictionary</key>
 	<dict>
-		<key>5F73378B-9B1E-4D93-A7B2-48552D49D55F</key>
+		<key>B5B95C91-889D-4DA8-8B25-2D38FEEB9B0B</key>
 		<string>..</string>
 	</dict>
 	<key>IDESourceControlProjectURL</key>
-	<string>ssh://github.com/Leandros/DropCloud.git</string>
+	<string>ssh://github.com/Leandros/ownDrop.git</string>
 	<key>IDESourceControlProjectVersion</key>
 	<integer>110</integer>
 	<key>IDESourceControlProjectWCCIdentifier</key>
-	<string>5F73378B-9B1E-4D93-A7B2-48552D49D55F</string>
+	<string>B5B95C91-889D-4DA8-8B25-2D38FEEB9B0B</string>
 	<key>IDESourceControlProjectWCConfigurations</key>
 	<array>
 		<dict>
 			<key>IDESourceControlRepositoryExtensionIdentifierKey</key>
 			<string>public.vcs.git</string>
 			<key>IDESourceControlWCCIdentifierKey</key>
-			<string>5F73378B-9B1E-4D93-A7B2-48552D49D55F</string>
+			<string>B5B95C91-889D-4DA8-8B25-2D38FEEB9B0B</string>
 			<key>IDESourceControlWCCName</key>
-			<string>DropCloud</string>
+			<string>ownDrop</string>
 		</dict>
 	</array>
 </dict>

--- a/DropCloud/AGAppDelegate.m
+++ b/DropCloud/AGAppDelegate.m
@@ -224,6 +224,11 @@
                     [self.recentDrops addObject:newDrop];
                     NSMenuItem *item = [[NSMenuItem alloc] initWithTitle:newDrop.fileName.lastPathComponent action:@selector(recentDropSelected:) keyEquivalent:@""];
                     [item setEnabled:YES];
+					
+					if (self.recentDrops.count == 1 && [[[self.recentDrops objectAtIndex:0] title] isEqualToString:@"No recent drops"]) {
+						[self.recentDrops removeObjectAtIndex:0];
+					}
+					
                     [self.statusMenu insertItem:item atIndex:0];
                     if (self.recentDrops.count > 5) {
                         [self.recentDrops removeLastObject];

--- a/DropCloud/AGAppDelegate.m
+++ b/DropCloud/AGAppDelegate.m
@@ -225,11 +225,12 @@
                     NSMenuItem *item = [[NSMenuItem alloc] initWithTitle:newDrop.fileName.lastPathComponent action:@selector(recentDropSelected:) keyEquivalent:@""];
                     [item setEnabled:YES];
 					
-					if (self.recentDrops.count == 1 && [[[self.recentDrops objectAtIndex:0] title] isEqualToString:@"No recent drops"]) {
-						[self.recentDrops removeObjectAtIndex:0];
+					if ([[[self.statusMenu itemAtIndex:0] title] isEqualToString:@"No recent drops"]) {
+						[self.statusMenu removeItemAtIndex:0];
 					}
-					
+                    
                     [self.statusMenu insertItem:item atIndex:0];
+                    
                     if (self.recentDrops.count > 5) {
                         [self.recentDrops removeLastObject];
                         [self.statusMenu removeItemAtIndex:5];


### PR DESCRIPTION
It's not really a bug but when you first start ownDrop and upload a file the menu item "No recent uploads" will still be there.

I've fixed it though I'm not sure this is the "right" way. This solution doesn't use localized strings so I'm not sure if it works in german environments.
