### PR TITLE
does not crash after upload, hotfix #18

### DIFF
--- a/DropCloud/AGAppDelegate.m
+++ b/DropCloud/AGAppDelegate.m
@@ -226,7 +226,9 @@
                     [self.recentDrops addObject:newDrop];
                     NSMenuItem *item = [[NSMenuItem alloc] initWithTitle:newDrop.fileName.lastPathComponent action:@selector(recentDropSelected:) keyEquivalent:@""];
                     [item setEnabled:YES];
-                    [self.statusMenu removeItem:self.noRecentDrops];
+                    if (self.noRecentDrops) {
+                        [self.statusMenu removeItem:self.noRecentDrops];
+                    }
                     [self.statusMenu insertItem:item atIndex:0];
                     if (self.recentDrops.count > 5) {
                         [self.recentDrops removeLastObject];


### PR DESCRIPTION
when there are any previous drops, self.noRecentDrops is nil and its removal from self.statusMenu was causing a crash
