### PR TITLE
Fix Icons in Dark Mode

### DIFF
--- a/DropCloud.xcodeproj/project.pbxproj
+++ b/DropCloud.xcodeproj/project.pbxproj
@@ -609,7 +609,7 @@
 		0C217A651927D6E100329724 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/DropCloud.app/Contents/MacOS/DropCloud";
+				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/ownDrop.app/Contents/MacOS/ownDrop";
 				COMBINE_HIDPI_IMAGES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
@@ -631,7 +631,7 @@
 		0C217A661927D6E100329724 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/DropCloud.app/Contents/MacOS/DropCloud";
+				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/ownDrop.app/Contents/MacOS/ownDrop";
 				COMBINE_HIDPI_IMAGES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(DEVELOPER_FRAMEWORKS_DIR)",

--- a/DropCloud/AGAppDelegate.m
+++ b/DropCloud/AGAppDelegate.m
@@ -71,6 +71,11 @@
     self.statusItem = [[NSStatusBar systemStatusBar] statusItemWithLength:STATUS_ITEM_VIEW_WIDTH];
     self.statusItemView = [[AGLoadingStatusItemView alloc] initWithStatusItem:self.statusItem];
     self.statusItemView.menu = self.statusMenu;
+    
+    NSString *osxMode = [[NSUserDefaults standardUserDefaults] stringForKey:@"AppleInterfaceStyle"];
+    if (osxMode == nil) self.statusItemView.isDarkMode = false;
+    else self.statusItemView.isDarkMode = true;
+    
     self.statusItemView.image = [NSImage imageNamed:@"menubar_icon"];
     self.statusItemView.highlightImage = [NSImage imageNamed:@"menubar_icon_inverse"];
     [self.statusItemView addObserver:@selector(fileDropped:) withTarget:self forEvent:AGStatusItemEventFileDropped];

--- a/DropCloud/CustomViews/AGLoadingStatusItemView.m
+++ b/DropCloud/CustomViews/AGLoadingStatusItemView.m
@@ -33,10 +33,11 @@
     if (self.isLoading) {
         if (!self.loadingView) {
             self.loadingView = [[AGLoadingView alloc] initWithFrame:NSMakeRect(0.0f, 0.0f, 18.0f, 18.0f)];
+            self.loadingView.isDarkMode = true;
         }
         [self.loadingView setProgress:self.progress];
         icon = [self imageFromView:self.loadingView];
-    } else if (self.isHighlighted) {
+    } else if (self.isHighlighted || self.isDarkMode) {
         icon = self.highlightImage;
     } else {
         icon = self.image;

--- a/DropCloud/CustomViews/AGLoadingView.h
+++ b/DropCloud/CustomViews/AGLoadingView.h
@@ -9,5 +9,6 @@
 @interface AGLoadingView : NSView
 
 @property (nonatomic, assign) float progress;
+@property (nonatomic) BOOL isDarkMode;
 
 @end

--- a/DropCloud/CustomViews/AGLoadingView.m
+++ b/DropCloud/CustomViews/AGLoadingView.m
@@ -20,7 +20,8 @@
     [emptyDropPath lineToPoint:NSMakePoint(9, 16)];
     [emptyDropPath lineToPoint:NSMakePoint(9, 16)];
     [emptyDropPath closePath];
-    [NSColor.blackColor setStroke];
+    if (self.isDarkMode) [NSColor.whiteColor setStroke];
+    else [NSColor.blackColor setStroke];
     [emptyDropPath setLineWidth:1];
     [emptyDropPath stroke];
 
@@ -168,10 +169,12 @@
         [bezier2Path lineToPoint: NSMakePoint(9.29, 15.46)];
         [bezier2Path closePath];
     }
-
-    [NSColor.blackColor setFill];
+    
+    if (self.isDarkMode) [NSColor.whiteColor setFill];
+    else [NSColor.blackColor setFill];
     [bezier2Path fill];
-    [NSColor.blackColor setStroke];
+    if (self.isDarkMode) [NSColor.whiteColor setStroke];
+    else [NSColor.blackColor setStroke];
     [bezier2Path setLineWidth:1];
     [bezier2Path stroke];
 }

--- a/DropCloud/CustomViews/AGStatusItemView.h
+++ b/DropCloud/CustomViews/AGStatusItemView.h
@@ -17,6 +17,7 @@ typedef NS_ENUM(NSUInteger, AGStatusItemEvent) {
 @property (nonatomic, strong) NSImage *image;
 @property (nonatomic, strong) NSImage *highlightImage;
 @property (nonatomic, assign, readonly) BOOL isHighlighted;
+@property (nonatomic) BOOL isDarkMode;
 
 - (id)initWithStatusItem:(NSStatusItem *)statusItem;
 - (void)addObserver:(SEL)observer withTarget:(id)target forEvent:(AGStatusItemEvent)event;

--- a/DropCloud/CustomViews/AGStatusItemView.m
+++ b/DropCloud/CustomViews/AGStatusItemView.m
@@ -138,7 +138,7 @@
 - (void)drawRect:(NSRect)dirtyRect {
     [self.statusItem drawStatusBarBackgroundInRect:dirtyRect withHighlight:self.isHighlighted];
 
-    NSImage *icon = self.isHighlighted ? self.highlightImage : self.image;
+    NSImage *icon = self.isHighlighted || self.isDarkMode ? self.highlightImage : self.image;
     NSSize iconSize = [icon size];
     NSRect bounds = self.bounds;
     CGFloat iconX = roundf((float) ((NSWidth(bounds) - iconSize.width) / 2));

--- a/DropCloud/CustomViews/AGStatusItemView.m
+++ b/DropCloud/CustomViews/AGStatusItemView.m
@@ -16,6 +16,8 @@
 
 @implementation AGStatusItemView
 
+@synthesize menu = _menu;
+
 #pragma mark -
 #pragma mark Initialization -
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,11 +1,11 @@
 PODS:
   - AFNetworking (2.4.1):
-    - AFNetworking/NSURLConnection
-    - AFNetworking/NSURLSession
-    - AFNetworking/Reachability
-    - AFNetworking/Security
-    - AFNetworking/Serialization
-    - AFNetworking/UIKit
+    - AFNetworking/NSURLConnection (= 2.4.1)
+    - AFNetworking/NSURLSession (= 2.4.1)
+    - AFNetworking/Reachability (= 2.4.1)
+    - AFNetworking/Security (= 2.4.1)
+    - AFNetworking/Serialization (= 2.4.1)
+    - AFNetworking/UIKit (= 2.4.1)
   - AFNetworking/NSURLConnection (2.4.1):
     - AFNetworking/Reachability
     - AFNetworking/Security
@@ -30,10 +30,10 @@ DEPENDENCIES:
   - Sparkle (~> 1)
 
 SPEC CHECKSUMS:
-  AFNetworking: 0aabc6fae66d6e5d039eeb21c315843c7aae51ab
-  ObjectiveRecord: 173527cdf923ee956f6b0a4430916534b54583f5
-  ObjectiveSugar: f48793f5902c77cfc02a4ce46d2e8ecddcad4dc2
-  Ono: 56b64b266667f012bce9885f7764bf65b84f027a
-  Sparkle: 5eb20bb37ca21e471dab8417dee880198d905327
+  AFNetworking: 41d45d2c14219af0fa5addf3cfd433a002c13c9f
+  ObjectiveRecord: f290d17272e476b3c881300910e98284200c54b6
+  ObjectiveSugar: a6a25f23d657c19df0a0b972466d5b5ca9f5295c
+  Ono: 5914aa3dbb6de821fc2ac3b687f3be536ed36615
+  Sparkle: 3adb45d38bcdf80caf505f2b4cd693031db70835
 
-COCOAPODS: 0.34.1
+COCOAPODS: 0.38.2


### PR DESCRIPTION
I check for DarkMode and use the inverse icon at all times and change the color to white in AGLoadingView to fix #25 
<img width="582" alt="bildschirmfoto 2015-09-15 um 19 30 39" src="https://cloud.githubusercontent.com/assets/1899308/9884506/5cff7308-5be0-11e5-9461-01c90ee72402.png">

Found the DarkMode check here: http://stackoverflow.com/a/25214873/2826540

My solution needs ownDrop to be restarted to change behavior, so it could be improved to check for Dark Mode automatically.
